### PR TITLE
Import Chef 12+ fix

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -96,3 +96,6 @@ suites:
   - name: networking
     run_list:
       - recipe[fake::networking]
+  - name: xinetd
+    run_list:
+      - recipe[fake::xinetd]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -22,3 +22,6 @@ suites:
   - name: networking
     run_list:
       - recipe[fake::networking]
+  - name: xinetd
+    run_list:
+      - recipe[fake::xinetd]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,8 +6,8 @@ platforms:
   - name: ubuntu-12.04
     run_list:
       - recipe[apt]
-  - name: centos-6.6
-  - name: centos-7.0
+  - name: centos-6.7
+  - name: centos-7.1
 
 suites:
   - name: default

--- a/libraries/rsync_serve.rb
+++ b/libraries/rsync_serve.rb
@@ -136,7 +136,10 @@ class Chef
       # @return [Hash]
       def rsync_modules
         rsync_resources.reduce({}) do |hash, resource|
-          if resource.config_path == new_resource.config_path && resource.action == :add
+          if resource.config_path == new_resource.config_path && (
+            resource.action == :add ||
+            resource.action.include?(:add)
+          )
             hash[resource.name] ||= {}
             resource_attributes.each do |key|
               value = resource.send(key)

--- a/test/fixtures/cookbooks/fake/recipes/xinetd.rb
+++ b/test/fixtures/cookbooks/fake/recipes/xinetd.rb
@@ -1,0 +1,11 @@
+include_recipe 'rsync::server'
+
+rsync_serve 'tmp' do
+  path '/tmp'
+  restart_service false
+end
+
+rsync_serve 'var-tmp' do
+  path '/var/tmp'
+  restart_service false
+end


### PR DESCRIPTION
This fixes an issue when using a Chef 12.5.1 client where it doesn't actually add any of the modules from the LWRP. I imported a fix from #chef-cookbooks/rsync#18 to resolve it and tested that it works.

I also updated the versions of CentOS to test against and also included a suite for testing xinetd which I apparently forgot to include last time.
